### PR TITLE
RHGをリンクにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Rubyで書かれたLALR(1) パーサジェネレーター [Racc](https://github.
 ## TODO
 
 * 参考文献や参考になるサイトをまとめる
-  * RHG
+  * [『Ruby ソースコード完全解説　Ruby Hacking Guide』(RHG)](https://i.loveruby.net/ja/rhg/book/)
 * Lexerについて説明する (chapter_7 or later)
 
 ## ライセンス


### PR DESCRIPTION
こちらの参考文献の項目は編集中だと思いますが、暫定的な段階でもリンクになっていると便利だと思います。チュートリアルを一緒に読み進めた方が、"RHG"が何の略か分からないということもありました。いかがでしょうか。
